### PR TITLE
Update for pandoc-types-1.23

### DIFF
--- a/pandoc-lens.cabal
+++ b/pandoc-lens.cabal
@@ -20,9 +20,9 @@ source-repository head
 library
   exposed-modules:     Text.Pandoc.Lens
   ghc-options:         -Wall -fno-warn-orphans
-  build-depends:       base >=4.7 && <4.15,
-                       containers >=0.5 && <0.7,
-                       pandoc-types >=1.20 && <1.21,
-                       lens >=4.2 && <4.20,
+  build-depends:       base >=4.7 && <4.21,
+                       containers >=0.5 && <0.8,
+                       pandoc-types >=1.23 && <1.24,
+                       lens >=4.2 && <5.4,
                        text
   default-language:    Haskell2010


### PR DESCRIPTION
Here's a few changes I needed to compile on a recent Stackage, plus a few I noticed while fixing.

---

For 1.23:

* Remove the _Null prism, following the Null constructor's removal from Block.
* Figure appears in blockPrePlate.

For 1.21:

* Update to the new Table structure.  Notably it has no visible Inline or Block children anymore, disappearing from plate-like traversals.

Prior:

* LineBlock appears in blockInlines.